### PR TITLE
Fixed typo when getting ecal energy in get_cluster_calib in main branch

### DIFF
--- a/generator_common.py
+++ b/generator_common.py
@@ -486,7 +486,7 @@ class MPGraphDataGenerator:
         #global node feature later
         
         if self.include_ecal:
-            cell_E_ecal = event_data[self.detector_name+".energy"]
+            cell_E_ecal = event_data[self.detector_ecal+".energy"]
             cluster_calib_E_ecal = np.sum(cell_E_ecal,axis=-1)
             cluster_calib_E += cluster_calib_E_ecal
 


### PR DESCRIPTION
Addresses issue #5 in the main branch.